### PR TITLE
feat(commitlint): husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,9 @@
+#!/bin/sh
+docker run --rm \
+  -v "$(pwd):/app" \
+  -w /app node:18 sh -c "
+    npm install --no-save @commitlint/cli @commitlint/config-conventional && \
+    npx commitlint --config commitlint.config.cjs --edit \"$1\"; EXIT_CODE=\$?; \
+    rm -rf /app/node_modules /app/package-lock.json; \
+    exit \$EXIT_CODE
+  "

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'type-enum': [
+            2,
+            'always',
+            [
+                'ci',
+                'chore',
+                'docs',
+                'ticket',
+                'feat',
+                'fix',
+                'perf',
+                'refactor',
+                'revert',
+                'style',
+            ],
+        ],
+    },
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-immpression",
   "version": "1.0.0",
-  "description": "",
+  "description": "Welcome to Immpression!",
   "main": "index.js",
   "type": "module",
   "scripts": {
@@ -30,5 +30,13 @@
     "nodemon": "^3.1.7",
     "playwright": "^1.49.0",
     "sharp": "^0.33.5"
+  },
+  "directories": {
+    "test": "tests"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.6.1",
+    "@commitlint/config-conventional": "^19.6.0",
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
husky spins up temporary docker container to validate commit messages. This eliminates the need of a node_modules folder to ues husky.