### PR TITLE
Store full artwork objects in DB instead of refs

### DIFF
--- a/models/featuredPublicArt.js
+++ b/models/featuredPublicArt.js
@@ -1,9 +1,21 @@
 import mongoose from "mongoose";
 
-const artworkRefSchema = new mongoose.Schema(
+// Full artwork object stored directly — no re-fetching from external APIs needed.
+const artworkSchema = new mongoose.Schema(
   {
-    source: { type: String, enum: ["met", "chicago", "cleveland", "wikimedia", "rijksmuseum"], required: true },
-    id: { type: String, required: true },
+    id:          { type: String, required: true },
+    source:      { type: String, enum: ["met", "chicago", "cleveland", "wikimedia", "rijksmuseum"], required: true },
+    title:       { type: String, default: "Untitled" },
+    artist:      { type: String, default: "Unknown Artist" },
+    year:        { type: String, default: null },
+    medium:      { type: String, default: null },
+    dimensions:  { type: String, default: null },
+    imageUrl:    { type: String, default: null },
+    thumbnailUrl:{ type: String, default: null },
+    description: { type: String, default: null },
+    department:  { type: String, default: null },
+    creditLine:  { type: String, default: null },
+    sourceUrl:   { type: String, default: null },
   },
   { _id: false }
 );
@@ -12,7 +24,7 @@ const artworkRefSchema = new mongoose.Schema(
 const featuredPublicArtSchema = new mongoose.Schema({
   key: { type: String, default: "default", unique: true },
   artworks: {
-    type: [artworkRefSchema],
+    type: [artworkSchema],
     validate: {
       validator: (arr) => arr.length <= 20,
       message: "Cannot feature more than 20 artworks.",

--- a/routes/admin-userAuthRoutes/admin-publicArtRoutes.js
+++ b/routes/admin-userAuthRoutes/admin-publicArtRoutes.js
@@ -36,6 +36,7 @@ router.put("/featured", isAdminAuthorized, async (req, res) => {
 
   try {
     const adminEmail = req.admin?.email || "unknown";
+    // artworks are full objects from the admin panel — store directly, no re-fetching needed
     await saveFeaturedArtworks(artworks, adminEmail);
     res.json({ success: true, message: `Saved ${artworks.length} featured artworks` });
   } catch (e) {

--- a/services/publicArt.js
+++ b/services/publicArt.js
@@ -438,25 +438,29 @@ const FALLBACK_FEATURED = [
 ];
 
 /**
- * Featured artworks — reads the admin-curated list from DB.
- * Falls back to hardcoded defaults if no list has been saved yet.
+ * Featured artworks — reads full artwork objects directly from DB.
+ * Falls back to fetching hardcoded defaults from external APIs only if DB is empty.
  */
 export async function getFeaturedArtworks() {
   const cacheKey = "featured";
   const cached = cacheGet(cacheKey);
   if (cached) return cached;
 
-  let refs;
   try {
     const FeaturedPublicArt = (await import("../models/featuredPublicArt.js")).default;
     const doc = await FeaturedPublicArt.findOne({ key: "default" }).lean();
-    refs = doc && doc.artworks.length > 0 ? doc.artworks : FALLBACK_FEATURED;
+
+    if (doc && doc.artworks.length > 0) {
+      cacheSet(cacheKey, doc.artworks);
+      return doc.artworks;
+    }
   } catch {
-    refs = FALLBACK_FEATURED;
+    // fall through to hardcoded defaults
   }
 
+  // No DB list yet — fetch hardcoded defaults from external APIs
   const results = await Promise.allSettled(
-    refs.map(({ source, id }) => getPublicArtwork(source, String(id)))
+    FALLBACK_FEATURED.map(({ source, id }) => getPublicArtwork(source, String(id)))
   );
 
   const artworks = results
@@ -468,13 +472,14 @@ export async function getFeaturedArtworks() {
 }
 
 /**
- * Save the admin-curated list and bust the featured cache.
+ * Save the full curated artwork objects to DB and bust the featured cache.
+ * The admin panel sends complete artwork objects so we never need to re-fetch.
  */
-export async function saveFeaturedArtworks(refs, updatedBy) {
+export async function saveFeaturedArtworks(artworks, updatedBy) {
   const FeaturedPublicArt = (await import("../models/featuredPublicArt.js")).default;
   await FeaturedPublicArt.findOneAndUpdate(
     { key: "default" },
-    { artworks: refs, updatedBy },
+    { artworks, updatedBy },
     { upsert: true, new: true }
   );
   cache.delete("featured");


### PR DESCRIPTION
Previously the featured endpoint re-fetched each artwork from external APIs on every cold Vercel start, causing timeouts. Now the admin saves full artwork objects to MongoDB, and the featured endpoint reads directly from DB with no external API calls needed.