### PR TITLE
Include sold artworks in marketplace and admin responses

### DIFF
--- a/routes/admin-userAuthRoutes/admin-userAuthRoutes.js
+++ b/routes/admin-userAuthRoutes/admin-userAuthRoutes.js
@@ -163,7 +163,9 @@ router.get("/all_images", isAdminAuthorized, async (req, res) => {
             views: image.views,
             category: image.category,
             createdAt: image.createdAt,
-            stage: image.stage, // ✅ Include the stage (useful for review)
+            stage: image.stage,
+            soldStatus: image.soldStatus || 'unsold',
+            isSold: image.soldStatus === 'sold',
         }));
 
         res.status(200).json({

--- a/routes/imageRoutes/imageRoutes.js
+++ b/routes/imageRoutes/imageRoutes.js
@@ -763,7 +763,7 @@ router.get('/marketplace', async (req, res) => {
   try {
     const { page = 1, limit = 48, category, sort = 'newest' } = req.query;
 
-    const query = { stage: 'approved', soldStatus: 'unsold' };
+    const query = { stage: 'approved' };
 
     if (category) {
       if (!IMAGE_CATEGORY.includes(category)) {
@@ -782,19 +782,27 @@ router.get('/marketplace', async (req, res) => {
 
     const skip = (page - 1) * limit;
 
-    const [images, totalImages] = await Promise.all([
+    const [images, totalImages, soldCount] = await Promise.all([
       ImageModel.find(query)
         .sort(sortOrder)
         .limit(Number(limit))
         .skip(skip)
-        .select('_id userId artistName name description price imageLink category createdAt dimensions weight isSigned isFramed views'),
+        .select('_id userId artistName name description price imageLink category createdAt dimensions weight isSigned isFramed views soldStatus'),
       ImageModel.countDocuments(query),
+      ImageModel.countDocuments({ ...query, soldStatus: 'sold' }),
     ]);
+
+    const mappedImages = images.map((img) => ({
+      ...img.toObject(),
+      isSold: img.soldStatus === 'sold',
+    }));
 
     res.status(200).json({
       success: true,
-      images,
+      images: mappedImages,
       totalImages,
+      soldImages: soldCount,
+      availableImages: totalImages - soldCount,
       totalPages: Math.ceil(totalImages / limit),
       currentPage: Number(page),
     });


### PR DESCRIPTION
/marketplace now returns all approved art (sold + unsold) with isSold flag and separate availableImages/soldImages counts. Admin /all_images response now includes soldStatus and isSold fields so the admin panel can display sold status alongside the review stage.


Claude-Session: https://claude.ai/code/session_01QK3pHMoW7QKDnr4DGNXcDe